### PR TITLE
ecoservice_financeinterface: fix incorrect context key

### DIFF
--- a/ecoservice_financeinterface/models/ecofi.py
+++ b/ecoservice_financeinterface/models/ecofi.py
@@ -201,8 +201,8 @@ class ecofi(osv.osv):
                 if len(sollnotax) == 1:
                     ecofikonto = sollnotax[0]
         if not ecofikonto:
-            if 'invoice_ids' in context:
-                invoice_ids = context['invoice_ids']
+            if context.get('invoice'):
+                invoice_ids = context['invoice'].ids
             else:
                 invoice_ids = self.pool.get('account.invoice').search(cr, uid, [('move_id', '=', move.id)])
             in_booking = False


### PR DESCRIPTION
Looks was not migrated fine from v7, invoice context already used and here: https://github.com/HBEE/accounting/blob/8.0-hbee/ecoservice_financeinterface_datev/models/account.py#L155